### PR TITLE
bugfix queue_size add

### DIFF
--- a/scripts/velControl.py
+++ b/scripts/velControl.py
@@ -22,7 +22,7 @@ def subpub_callback(data):
 	elif control_turn > 0.5:
 			control_turn = 3
 
-	vel_pub = rospy.Publisher('cmd_vel_mux/input/teleop', Twist)
+	vel_pub = rospy.Publisher('cmd_vel_mux/input/teleop', Twist, queue_size=1)
 	twist = Twist()
 	twist.linear.x = control_speed
 	twist.linear.y = 0


### PR DESCRIPTION
## バグフィクス
バグ内容 :  cmd_vel/ topicの更新が速すぎる場合にロボットがうまく動かない

解決策 :  速度制限ノードのパブリッシャーのキューに溜まっているようだったので、キューサイズを1に設定しました。